### PR TITLE
Setting routing key for publishing mailchimp status messages

### DIFF
--- a/MBC_UserRegistration.class.inc
+++ b/MBC_UserRegistration.class.inc
@@ -33,7 +33,7 @@ class MBC_UserRegistration
    * @var array
    */
   private $credentials;
-  
+
   /**
    * The number of queue entries to process in each session
    */
@@ -319,9 +319,9 @@ class MBC_UserRegistration
       'password' => getenv("RABBITMQ_PASSWORD"),
       'vhost' => getenv("RABBITMQ_VHOST"),
     );
-    $credentials['mailchimp_apikey'] = getenv("MAILCHIMP_APIKEY");
 
     $config = array(
+      'routingKey' => getenv('MB_USER_MAILCHIMP_STATUS_ROUTING_KEY'),
       'exchange' => array(
         'name' => getenv("MB_USER_MAILCHIMP_STATUS_EXCHANGE"),
         'type' => getenv("MB_USER_MAILCHIMP_STATUS_EXCHANGE_TYPE"),


### PR DESCRIPTION
Because it's a direct exchange, a routing key does need to be set. The consumer is already set to listen off of this key.

Note that messages sitting in the queue right now won't be properly consumed because they have no routing key set.
