### PR TITLE
Changes MailChimp list id from configuration setting to payload setting.

### DIFF
--- a/MBC_UserRegistration.class.inc
+++ b/MBC_UserRegistration.class.inc
@@ -36,7 +36,7 @@ class MBC_UserRegistration
    * @var array
    */
   private $credentials;
-  
+
   /**
    * Setting from external services - Mailchimp.
    *
@@ -108,42 +108,53 @@ class MBC_UserRegistration
     while ($messageCount > 0 && $processedCount < self::BATCH_SIZE) {
       $messageDetails = $this->channel->basic_get($this->config['queue']['registrations']['name']);
       $messagePayload = unserialize($messageDetails->body);
-      $newSubscribers[$processedCount] = array(
-        'email' => $messagePayload['email'],
-        'mb_delivery_tag' => $messageDetails->delivery_info['delivery_tag'],
-      );
-      if (isset($messagePayload['merge_vars']['FNAME'])) {
-        $newSubscribers[$processedCount]['fname'] = $messagePayload['merge_vars']['FNAME'];
-      }
-      if (isset($messagePayload['uid'])) {
-        $newSubscribers[$processedCount]['uid'] = $messagePayload['uid'];
-      }
-      if (isset($messagePayload['birthdate_timestamp'])) {
-        $newSubscribers[$processedCount]['birthdate_timestamp'] = $messagePayload['birthdate_timestamp'];
-      }
-      elseif (isset($messagePayload['birthdate'])) {
-        $newSubscribers[$processedCount]['birthdate_timestamp'] = $messagePayload['birthdate'];
-      }
-      if (isset($messagePayload['mobile'])) {
-        $newSubscribers[$processedCount]['mobile'] = $messagePayload['mobile'];
-      }
-      if (isset($messagePayload['source'])) {
-        $newSubscribers[$processedCount]['source'] = $messagePayload['source'];
+
+      $mlid = !empty($messagePayload['mailchimp_list_id']) ? $messagePayload['mailchimp_list_id'] : false;
+      if ($mlid) {
+        $subscriber = &$newSubscribers[$mlid][];
+        $subscriber['email'] = $messagePayload['email'];
+        $subscriber['mb_delivery_tag'] = $messageDetails->delivery_info['delivery_tag'];
+
+        if (isset($messagePayload['merge_vars']['FNAME'])) {
+          $subscriber['fname'] = $messagePayload['merge_vars']['FNAME'];
+        }
+        if (isset($messagePayload['uid'])) {
+          $subscriber['uid'] = $messagePayload['uid'];
+        }
+        if (isset($messagePayload['birthdate_timestamp'])) {
+          $subscriber['birthdate_timestamp'] = $messagePayload['birthdate_timestamp'];
+        }
+        elseif (isset($messagePayload['birthdate'])) {
+          $subscriber['birthdate_timestamp'] = $messagePayload['birthdate'];
+        }
+        if (isset($messagePayload['mobile'])) {
+          $subscriber['mobile'] = $messagePayload['mobile'];
+        }
+        if (isset($messagePayload['source'])) {
+          $subscriber['source'] = $messagePayload['source'];
+        }
       }
 
       $messageCount--;
       $processedCount++;
     }
 
-    list($composedSubscriberList, $mbDeliveryTags) = $this->composeSubscriberSubmission($newSubscribers);
-    if (count($composedSubscriberList) > 0) {
-      $results = $this->submitToMailChimp($composedSubscriberList, $mbDeliveryTags);
+    if (empty($newSubscribers)) {
+      return 'No new accounts to submit to MailChimp.';
+    }
+
+    $results = '';
+    foreach ($newSubscribers as $mlid => $subscribers) {
+      list($composedSubscriberList, $mbDeliveryTags) = $this->composeSubscriberSubmission($subscribers);
+      if (count($composedSubscriberList) < 1) {
+        $results .= 'No new accounts to submit to MailChimp list' . $mlid . '.' . PHP_EOL;
+        continue;
+      }
+
+      $results .= $this->submitToMailChimp($mlid, $composedSubscriberList, $mbDeliveryTags);
       $this->statHat->clearAddedStatNames();
       $this->statHat->addStatName('consumeNewRegistrationsQueue');
       $this->statHat->reportCount($processedCount);
-    }
-    else {
-      $results = 'No new accounts to submit to MailChimp.';
     }
 
     return $results;
@@ -174,9 +185,10 @@ class MBC_UserRegistration
       $messageDetails = $this->channel->basic_get($this->config['queue']['campaign_signups']['name']);
       $messagePayload = unserialize($messageDetails->body);
 
-      if (isset($messagePayload['mailchimp_group_name']) && $messagePayload['mailchimp_group_name'] != '') {
+      $mlid = !empty($messagePayload['mailchimp_list_id']) ? $messagePayload['mailchimp_list_id'] : false;
+      if ($mlid && !empty($messagePayload['mailchimp_group_name'])) {
 
-        $campaignSignups[] = array(
+        $campaignSignups[$mlid][] = array(
           'email' => $messagePayload['email'],
           'mb_delivery_tag' => $messageDetails->delivery_info['delivery_tag'],
           'mailchimp_group_name' => $messagePayload['mailchimp_group_name'],
@@ -188,22 +200,29 @@ class MBC_UserRegistration
         // No group setting, skip entry in batch submission. Send acknowledgment
         // to remove entry from queue
         $this->channel->basic_ack($messageDetails->delivery_info['delivery_tag']);
-        echo $messagePayload['email'] . ' skipped, no group_name.',  "\n";
+        echo $messagePayload['email'] . ' skipped, no group_name.',  PHP_EOL;
       }
 
       $messageCount--;
       $messagesProcessed++;
     }
 
-    list($composedSignupList, $mbDeliveryTags) = $this->composeSignupSubmission($campaignSignups);
-    if (count($composedSignupList)) {
-      $results = $this->submitToMailChimp($composedSignupList, $mbDeliveryTags);
+    if (empty($campaignSignups)) {
+      return 'No new campaign signups accounts to submit to MailChimp.';
+    }
+
+    $results = '';
+    foreach ($campaignSignups as $mlid => $signups) {
+      list($composedSignupList, $mbDeliveryTags) = $this->composeSubscriberSubmission($signups);
+      if (count($composedSignupList) < 1) {
+        $results .= 'No new campaign signups accounts to submit to MailChimp list' . $mlid . '.' . PHP_EOL;
+        continue;
+      }
+
+      $results .= $this->submitToMailChimp($mlid, $composedSignupList, $mbDeliveryTags);
       $this->statHat->clearAddedStatNames();
       $this->statHat->addStatName('consumeMailchimpCampaignSignupQueue');
       $this->statHat->reportCount($messagesProcessed);
-    }
-    else {
-      $results = 'No new campaign signups accounts to submit to MailChimp.';
     }
 
     return $results;
@@ -308,6 +327,9 @@ class MBC_UserRegistration
   /**
    * Make signup submission to MailChimp
    *
+   * @param string $mlid
+   *   The MailChimp list id to connect to.
+   *
    * @param array $composedBatch
    *   The list of email address to be submitted to MailChimp
    *
@@ -318,7 +340,7 @@ class MBC_UserRegistration
    *   A list of the RabbitMQ queue entry IDs that have been successfully
    *   submitted to MailChimp.
    */
-  private function submitToMailChimp($composedBatch = array(), $mbDeliveryTags = array()) {
+  private function submitToMailChimp($mlid, $composedBatch = array(), $mbDeliveryTags = array()) {
 
     $MailChimp = new \Drewm\MailChimp($this->settings['mailchimp_apikey']);
 
@@ -336,24 +358,24 @@ class MBC_UserRegistration
     $results['update_count'] = 0;
 
     $results = $MailChimp->call("lists/batch-subscribe", array(
-      'id' => $this->settings['mailchimp_list_id'],
+      'id' => $mlid,
       'batch' => $composedBatch,
       'double_optin' => FALSE,
       'update_existing' => TRUE,
       'replace_interests' => FALSE,
     ));
 
-    $status = '------- ' . date('D M j G:i:s:u T Y') . ' -------' . "\n";
+    $status = '------- ' . date('D M j G:i:s:u T Y') . ' -------' . PHP_EOL;
     if ($results != 0) {
       if ($results['error_count'] > 0) {
         $this->updateUserMailchimpError($results['errors'], $composedBatch);
-        $status .= 'mbc-registration-email - submitToMailChimp(): Success with errors!' . "\n";
+        $status .= 'mbc-registration-email - submitToMailChimp(): Success with errors!' . PHP_EOL;
       }
       else {
-        $status .= 'mbc-registration-email - submitToMailChimp(): Success!' . "\n";
+        $status .= 'mbc-registration-email - submitToMailChimp(): Success!' . PHP_EOL;
       }
-      $status .= ' [x] ' . $results['add_count'] . ' email addresses added / ' . $results['update_count'] . ' updated.' . "\n";
-      
+      $status .= ' [x] ' . $results['add_count'] . ' email addresses added / ' . $results['update_count'] . ' updated.' . PHP_EOL;
+
       $this->statHat->clearAddedStatNames();
       $this->statHat->addStatName('submitToMailChimp-batch-subscribe add_count');
       $this->statHat->reportCount($results['add_count']);
@@ -408,7 +430,7 @@ class MBC_UserRegistration
       else {
         $payload = serialize($errorDetails);
         $mbError->publishMessage($payload);
-        
+
         $this->statHat->clearAddedStatNames();
         $this->statHat->addStatName('updateUserMailchimpError - Other');
         $this->statHat->reportCount(1);

--- a/MBC_UserRegistration.class.inc
+++ b/MBC_UserRegistration.class.inc
@@ -368,7 +368,7 @@ class MBC_UserRegistration
     $status = '------- ' . date('D M j G:i:s:u T Y') . ' -------' . PHP_EOL;
     if ($results != 0) {
       if ($results['error_count'] > 0) {
-        $this->updateUserMailchimpError($results['errors'], $composedBatch);
+        $this->updateUserMailchimpError($results['errors'], $mlid, $composedBatch);
         $status .= 'mbc-registration-email - submitToMailChimp(): Success with errors!' . PHP_EOL;
       }
       else {
@@ -407,11 +407,14 @@ class MBC_UserRegistration
    * @param array $errors
    *   A list of RabbitMQ delivery tags being processed in batch.
    *
+   * @param string $mlid
+   *   The MailChimp list id to connect to.
+   *
    * @param array $composedBatch
    *  List or email address and their Mailchimp interest group assignments that
    *  were submitted as a batch.
    */
-  private function updateUserMailchimpError($errors, $composedBatch) {
+  private function updateUserMailchimpError($errors, $mlid, $composedBatch) {
 
     $status = NULL;
     $cfg = $this->config;
@@ -425,7 +428,7 @@ class MBC_UserRegistration
       // transaction / user signing up for a campaign is confirmation that
       // they want to resubscribe.
       if ($errorDetails['code'] == 212) {
-        $status = $this->resubscribeEmail($errorDetails, $composedBatch);
+        $status = $this->resubscribeEmail($errorDetails, $mlid, $composedBatch);
       }
       else {
         $payload = serialize($errorDetails);
@@ -449,6 +452,9 @@ class MBC_UserRegistration
    *   The error details reported when the email address was submitted as a part
    *   of a batch submission.
    *
+   *  @param string $mlid
+   *   The MailChimp list id to connect to.
+   *
    * @param array $composedBatch
    *   The details of the batch data sent to Mailchimp. The interest group
    *   details will be extractacted for the /lists/subscribe submission to
@@ -457,7 +463,7 @@ class MBC_UserRegistration
    * @return string $status
    *   The results of the submission to the UserAPI
    */
-  private function resubscribeEmail($errorDetails, $composedBatch) {
+  private function resubscribeEmail($errorDetails, $mlid, $composedBatch) {
 
     // Lookup the group assignment details from $composedBatch by the email
     // address in $errorDetails
@@ -472,7 +478,7 @@ class MBC_UserRegistration
     $mc = new \Drewm\MailChimp($this->settings['mailchimp_apikey']);
 
     $results = $mc->call("lists/subscribe", array(
-      'id' => $this->settings['mailchimp_list_id'],
+      'id' => $mlid,
       'email' => array(
         'email' => $composedItem['email']['email']
         ),

--- a/mbc-registration-email.php
+++ b/mbc-registration-email.php
@@ -66,7 +66,6 @@ $config = array(
 );
 $settings = array(
   'mailchimp_apikey' => getenv("MAILCHIMP_APIKEY"),
-  'mailchimp_list_id' => getenv("MAILCHIMP_LIST_ID"),
   'stathat_ez_key' => getenv("STATHAT_EZKEY"),
 );
 


### PR DESCRIPTION
#### What's this PR do?

This PR refactors MailChimp list id.
MailChimp list id will no longer be preconfigured by the environment, but sent with payloads data instead, as designated in DoSomething/dosomething#4076.
#### Any background context you want to provide?

This change presorts email batches sent to MailChimp based on the list id and sends each batch per each list id separately.
#### What are the relevant tickets?
- Ref DoSomething/dosomething#4076
- A part of DoSomething/dosomething#4058
- Closes #45
