### PR TITLE
Issue60 re and unsubscribes

### DIFF
--- a/mbc-registration-email_userRegistration.php
+++ b/mbc-registration-email_userRegistration.php
@@ -8,11 +8,6 @@
  * segments for mass mailouts.
  */
 
- $bla = FALSE;
-if ($bla) {
-  $bla = TRUE;
-}
-
 date_default_timezone_set('America/New_York');
 define('CONFIG_PATH',  __DIR__ . '/messagebroker-config');
 // The number of messages for the consumer to reserve with each callback

--- a/mbc-registration-email_userRegistration.php
+++ b/mbc-registration-email_userRegistration.php
@@ -8,13 +8,18 @@
  * segments for mass mailouts.
  */
 
+ $bla = FALSE;
+if ($bla) {
+  $bla = TRUE;
+}
+
 date_default_timezone_set('America/New_York');
 define('CONFIG_PATH',  __DIR__ . '/messagebroker-config');
 // The number of messages for the consumer to reserve with each callback
 // See consumeMwessage for further details.
 // Necessary for parallel processing when more than one consumer is running on the same queue.
 define('QOS_SIZE', 1);
-define('BATCH_SIZE', 100);
+define('BATCH_SIZE', 1);
 
 // Load up the Composer autoload magic
 require_once __DIR__ . '/vendor/autoload.php';

--- a/mbc-registration-email_userRegistrations.config.inc
+++ b/mbc-registration-email_userRegistrations.config.inc
@@ -36,6 +36,7 @@ $mbConfig->setProperty('rabbit_credentials', [
   'password' => getenv("RABBITMQ_PASSWORD"),
   'vhost' => getenv("RABBITMQ_VHOST"),
 ]);
+$rabbitCredentials = $mbConfig->getProperty('rabbit_credentials');
 $mbConfig->setProperty('rabbitapi_credentials', [
   'host' =>  getenv("MB_RABBITMQ_MANAGEMENT_API_HOST"),
   'port' => getenv("MB_RABBITMQ_MANAGEMENT_API_PORT"),
@@ -46,10 +47,14 @@ $mbConfig->setProperty('rabbitapi_credentials', [
 // Create connection to exchange and queue for processing of queue contents.
 $mbRabbitConfig = $mbConfig->constructRabbitConfig('transactionalExchange', array('userRegistrationQueue'));
 $mbConfig->setProperty('messageBroker_config', $mbRabbitConfig);
-
-$rabbitCredentials = $mbConfig->getProperty('rabbit_credentials');
 $messageBrokerConfig = $mbConfig->getProperty('messageBroker_config');
 $mbConfig->setProperty('messageBroker', new MessageBroker($rabbitCredentials, $messageBrokerConfig));
+
+// Manage re and un subscribes as reported by MailChimp response to initial subscribes
+$mbRabbitConfig_Subscribes = $mbConfig->constructRabbitConfig('transactionalExchange', array('userMailchimpStatusQueue'));
+$mbConfig->setProperty('messageBrokerSubscribes_config', $mbRabbitConfig_Subscribes);
+$messageBrokerSubscribesConfig = $mbConfig->getProperty('messageBrokerSubscribes_config');
+$mbConfig->setProperty('messageBroker_Subscribes', new MessageBroker($rabbitCredentials, $messageBrokerSubscribesConfig));
 
 $mbConfig->setProperty('mbRabbitMQManagementAPI', new MB_RabbitMQManagementAPI([
   'domain' => getenv("MB_RABBITMQ_MANAGEMENT_API_HOST"),

--- a/mbc-registration-email_userSubscriptions.php
+++ b/mbc-registration-email_userSubscriptions.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * mbc-registration-email_userSubscriptions
+ *
+ */
+
+date_default_timezone_set('America/New_York');
+define('CONFIG_PATH',  __DIR__ . '/messagebroker-config');
+// The number of messages for the consumer to reserve with each callback
+// See consumeMwessage for further details.
+// Necessary for parallel processing when more than one consumer is running on the same queue.
+define('QOS_SIZE', 1);
+
+// Load up the Composer autoload magic
+require_once __DIR__ . '/vendor/autoload.php';
+use DoSomething\MBC_RegistrationEmail\MBC_RegistrationEmail_UserSubscriptions_Consumer;
+
+require_once __DIR__ . '/mbc-registration-email_userSubscriptions.config.inc';
+
+// Kick off
+echo '------- mbc-registration-email_userSubscription START: ' . date('j D M Y G:i:s T') . ' -------', PHP_EOL;
+
+$mb = $mbConfig->getProperty('messageBroker_Subscribes');
+$mb->consumeMessage(array(new MBC_RegistrationEmail_UserSubscriptions_Consumer(), 'consumeUserMailchimpStatusQueue'), QOS_SIZE);
+
+echo '-------mbc-registration-email_useerSubscriptions END: ' . date('j D M Y G:i:s T') . ' -------', PHP_EOL;

--- a/src/MBC_RegistrationEmail_SubmissionErrors.php
+++ b/src/MBC_RegistrationEmail_SubmissionErrors.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * MBC_RegistrationEmail_SubmissionErrors:  
+ */
+
+namespace DoSomething\MBC_RegistrationEmail;
+
+use DoSomething\MB_Toolbox\MB_Configuration;
+use DoSomething\MBStatTracker\StatHat;
+use \Exception;
+
+/**
+ *MBC_RegistrationEmailSubmissionErrors class - .
+ */
+class MBC_RegistrationEmail_SubmissionErrors
+{
+
+  /**
+   * MailChimp objects
+   */
+  protected $mailChimp;
+
+  /**
+   *
+   */
+  public function __construct($mailChimp) {
+
+    $this->mailChimp = $mailChimp;
+    
+    $this->mbConfig = MB_Configuration::getInstance();
+    $this->messageBroker = $this->mbConfig->getProperty('messageBrokerErrors');
+  }
+
+  /**
+   *
+   */
+  protected function processErrorSubmissions($errors, $composedBatch) {
+    
+    $routingKey = 'user.mailchimp.error';
+
+    // Add extries for each error encountered to the directUserStatusExchange
+    foreach ($errors as $errorDetails){
+      // Resubscribe if email address is reported as unsubscribed - the
+      // transaction / user signing up for a campaign is confirmation that
+      // they want to resubscribe.
+      if ($errorDetails['code'] == 212) {
+        $this->resubscribeEmail($errorDetails, $composedBatch);
+      }
+      else {
+        $payload = serialize($errorDetails);
+        $this->messageBroker->publish($payload, $routingKey);
+      }
+    }
+  }
+   
+  /**
+   * Resubscribe email address with interest group assignment - submit queue
+   * entry to mailchimpCampaignSignupQueue
+   *
+   * @param array $errorDetails
+   *   The error details reported when the email address was submitted as a part
+   *   of a batch submission.
+   * @param array $composedBatch
+   *   The details of the batch data sent to Mailchimp. The interest group
+   *   details will be extractacted for the /lists/subscribe submission to
+   *   Mailchimp
+   *
+   * @return string $status
+   *   The results of the submission to the UserAPI
+   */
+  private function resubscribeEmail($errorDetails, $composedBatch) {
+    // Lookup the group assignment details from $composedBatch by the email
+    // address in $errorDetails
+    foreach ($composedBatch as $composedItemCount => $composedItem) {
+      if ($composedItem['email']['email'] == $errorDetails['email']['email']) {
+        $resubscribeDetails = $composedItem;
+        break;
+      }
+    }
+    $results = $this->mailChimp->submitToMailChimp($resubscribeDetails);
+    
+    // Keep track of successful resubscribes
+    // $resubscribeStatus ? $resubscribes++ : $failedResubscribes++;
+  }
+}

--- a/src/MBC_RegistrationEmail_UserRegistration_Consumer.php
+++ b/src/MBC_RegistrationEmail_UserRegistration_Consumer.php
@@ -115,8 +115,8 @@ class MBC_RegistrationEmail_UserRegistration_Consumer extends MB_Toolbox_BaseCon
             $this->channel->basic_cancel($this->message['original']->delivery_info['consumer_tag']);
           }
           if (isset($results['error_count']) > 0) {
-            $processSubmissionErrors = new MBC_RegistrationEmail_SubmissionErrors($this->mbcURMailChimp[$country]);
-            $processSubmissionErrors->processSubmissionErrors($results['errors']);
+            // $processSubmissionErrors = new MBC_RegistrationEmail_SubmissionErrors($this->mbcURMailChimp[$country]);
+            // $processSubmissionErrors->processSubmissionErrors($results['errors'], $composedBatch);
 
           }
         }

--- a/src/MBC_RegistrationEmail_UserRegistration_Consumer.php
+++ b/src/MBC_RegistrationEmail_UserRegistration_Consumer.php
@@ -105,13 +105,14 @@ class MBC_RegistrationEmail_UserRegistration_Consumer extends MB_Toolbox_BaseCon
             $composedBatch = $this->mbcURMailChimp[$country]->composeSubscriberSubmission($submissions);
             $results = $this->mbcURMailChimp[$country]->submitBatchToMailChimp($list_id, $composedBatch);
             echo '** ' . $results['add_count'] . ' added, ' . $results['update_count'] . ' updated and ' . $results['error_count'] . ' errors.', PHP_EOL . PHP_EOL;
+
+            if (isset($results['error_count']) > 0) {
+              $this->processErrorSubmissions($results['errors'], $country, $composedBatch);
+            }
           }
           catch(Exception $e) {
             echo 'Error: Failed to submit batch to ' . $country . ' MailChimp account. Error: ' . $e->getMessage(), PHP_EOL;
             $this->channel->basic_cancel($this->message['original']->delivery_info['consumer_tag']);
-          }
-          if (isset($results['error_count']) > 0) {
-            // $this->processErrorSubmissions($results['errors']);
           }
         }
       }
@@ -234,6 +235,62 @@ class MBC_RegistrationEmail_UserRegistration_Consumer extends MB_Toolbox_BaseCon
     // object and related account to submit to.
     $this->waitingSubmissions[$this->submission['user_country']][$this->submission['mailchimp_list_id']][] = $this->submission;
     unset($this->submission);
+  }
+
+  /**
+   *
+   */
+  protected function processErrorSubmissions($errors, $country, $composedBatch) {
+
+    $resubscribes = 0;
+    $failedResubscribes = 0;
+
+    // Add extry for each error encountered to the directUserStatusExchange
+    foreach ($errors as $errorDetails){
+
+      // Resubscribe if email address is reported as unsubscribed - the
+      // transaction / user signing up for a campaign is confirmation that
+      // they want to resubscribe.
+      if ($errorDetails['code'] == 212) {
+        $resubscribeStatus = $this->resubscribeEmail($errorDetails, $composedBatch);
+        $resubscribeStatus ? $resubscribes++ : $failedResubscribes++;
+      }
+      else {
+        $payload = serialize($errorDetails);
+        $mbError->publish($payload, 'user.mailchimp.error');
+      }
+    }
+  }
+
+  /**
+   *
+   */
+  protected function resubscribeEmail() {
+
+    // Lookup the group assignment details from $composedBatch by the email
+    // address in $errorDetails
+    foreach ($composedBatch as $composedItemCount => $composedItem) {
+      if ($composedItem['email']['email'] == $errorDetails['email']['email']) {
+        $resubscribeDetails = $composedItem;
+        break;
+      }
+    }
+
+    // Submit subscription to Mailchimp
+    $mc = new \Drewm\MailChimp($mAPIKey);
+
+    $results = $mc->call("lists/subscribe", array(
+      'id' => $mlid,
+      'email' => array(
+        'email' => $resubscribeDetails['email']['email']
+        ),
+      'merge_vars' => $resubscribeDetails['merge_vars'],
+      'double_optin' => FALSE,
+      'update_existing' => TRUE,
+      'replace_interests' => FALSE,
+      'send_welcome' => FALSE,
+    ));
+
   }
 
   /**


### PR DESCRIPTION
Fixes #60 

When user's are rejected by MailChimp batch subscribe submissions:
- attempt to resubscribe (a transaction indicates the user is opting back in to email) the address as a single submission
- single subscribe submisisons that return an error from MailChimp are marked as "banned" with error message details via `mb-user-api`.