### PR TITLE
Issue61 campaign signup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "mbc-registration-email",
   "type": "project",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A consumer app for the Message Broker system that consumes entries on the userRegistrationQueue. Queue payload values determine the account created on Mailchimp. Error messages returned about submitted email addresses submitted to Mailchimp are sent to the userMailchimpStatusQueue.",
   "keywords": ["message broker", "mailchimp", "email"],
   "homepage": "https://github.com/DoSomething/mbc-registration-email",

--- a/mbc-registration-email_campaignSignup.config.inc
+++ b/mbc-registration-email_campaignSignup.config.inc
@@ -15,6 +15,7 @@
  */
 use DoSomething\MB_Toolbox\MB_Configuration;
 use DoSomething\MB_Toolbox\MB_RabbitMQManagementAPI;
+use DoSomething\MB_Toolbox\MB_MailChimp;
 use DoSomething\StatHat\Client as StatHat;
 
 // Load configuration settings common to the Message Broker system
@@ -50,12 +51,28 @@ $rabbitCredentials = $mbConfig->getProperty('rabbit_credentials');
 $messageBrokerConfig = $mbConfig->getProperty('messageBroker_config');
 $mbConfig->setProperty('messageBroker', new MessageBroker($rabbitCredentials, $messageBrokerConfig));
 
+$mbConfig->setProperty('mbRabbitMQManagementAPI', new MB_RabbitMQManagementAPI([
+  'domain' => getenv("MB_RABBITMQ_MANAGEMENT_API_HOST"),
+  'port' => getenv('MB_RABBITMQ_MANAGEMENT_API_PORT'),
+  'vhost' => getenv('MB_RABBITMQ_MANAGEMENT_API_VHOST'),
+  'username' => getenv('MB_RABBITMQ_MANAGEMENT_API_USERNAME'),
+  'password' => getenv('MB_RABBITMQ_MANAGEMENT_API_PASSWORD')
+]));
+
 $mbConfig->setProperty('mailchimpAPIkeys', [
   'country' => [
     'global' => getenv("MAILCHIMP_APIKEY"),
     'us'     => getenv("MAILCHIMP_APIKEY"),
+    'gb'     => getenv("MAILCHIMP_UK_APIKEY"),
     'uk'     => getenv("MAILCHIMP_UK_APIKEY"),
     'mx'     => getenv("MAILCHIMP_MX_APIKEY"),
     'br'     => getenv("MAILCHIMP_BR_APIKEY"),
   ]]
 );
+
+$mailchimpAPIKeys = $mbConfig->getProperty('mailchimpAPIkeys');
+$mcObjects = [];
+foreach ($mailchimpAPIKeys['country'] as $country => $key) {
+  $mcObjects[$country] = new MB_MailChimp($key);
+}
+$mbConfig->setProperty('mbcURMailChimp_Objects', $mcObjects);

--- a/mbc-registration-email_userRegistrations.config.inc
+++ b/mbc-registration-email_userRegistrations.config.inc
@@ -68,6 +68,7 @@ $mbConfig->setProperty('mailchimpAPIkeys', [
   'country' => [
     'global' => getenv("MAILCHIMP_APIKEY"),
     'us'     => getenv("MAILCHIMP_APIKEY"),
+    'gb'     => getenv("MAILCHIMP_UK_APIKEY"),
     'uk'     => getenv("MAILCHIMP_UK_APIKEY"),
     'mx'     => getenv("MAILCHIMP_MX_APIKEY"),
     'br'     => getenv("MAILCHIMP_BR_APIKEY"),

--- a/src/MBC_RegistrationEmail_CampaignSignup_Consumer.php
+++ b/src/MBC_RegistrationEmail_CampaignSignup_Consumer.php
@@ -23,6 +23,12 @@ class MBC_RegistrationEmail_CampaignSignup_Consumer extends MB_Toolbox_BaseConsu
   const BATCH_SIZE = 100;
 
   /**
+   * Submissions to be sent to MailChimp, indexed by MailChimp API and email address.
+   * @var array $waitingSubmissions
+   */
+  protected $waitingSubmissions;
+
+  /**
    * consumeCampaignSignupQueue: Callback method for when messages arrive in the CampaignSignupQueue.
    *
    * Batches of email messages result in an email address being updated with MailChimp interest group.
@@ -32,7 +38,7 @@ class MBC_RegistrationEmail_CampaignSignup_Consumer extends MB_Toolbox_BaseConsu
    * @param string $payload
    *   A serialized message to be processed.
    */
-  public function consumeCampaignSignupQueue($payload) {
+  public function consumeMailchimpCampaignSignupQueue($payload) {
 
     echo '-------  mbc-registration-email - MBC_RegistrationEmail_CampaignSignup_Consumer->consumeCampaignSignupQueue() START -------', PHP_EOL;
 
@@ -63,11 +69,12 @@ class MBC_RegistrationEmail_CampaignSignup_Consumer extends MB_Toolbox_BaseConsu
       // origin queue, processing app. The "dead messages" queue can be used to monitor health.
     }
 
-    // @todo: Throttle the number of consumers running. Based on the number of messages
-    // waiting to be processed start / stop consumers. Make "reactive"!
-    $queueMessages = parent::queueStatus('transactionalQueue');
-    echo '- queueMessages ready: ' . $queueMessages['ready'], PHP_EOL;
-    echo '- queueMessages unacked: ' . $queueMessages['unacked'], PHP_EOL;
+   if ($this->canProcessSubmissions()) {
+
+      $this->processSubmissions();
+      echo '- unset $this->waitingSubmissions: ' . count($this->waitingSubmissions), PHP_EOL . PHP_EOL;
+      unset($this->waitingSubmissions);
+    }
 
     echo '-------  mbc-registration-email - MBC_RegistrationEmail_CampaignSignup_Consumer->consumeCampaignSignupQueue() END -------', PHP_EOL . PHP_EOL;
 
@@ -80,6 +87,20 @@ class MBC_RegistrationEmail_CampaignSignup_Consumer extends MB_Toolbox_BaseConsu
    */
   protected function canProcess() {
 
+    if (!(isset($this->message['mailchimp_list_id']))) {
+      echo '- canProcess() - mailchimp_list_id not set.', PHP_EOL;
+      return FALSE;
+    }
+    if (!(isset($this->message['mailchimp_group_name']))) {
+      echo '- canProcess() - mailchimp_group_name not set.', PHP_EOL;
+      return FALSE;
+    }
+
+    if (isset($this->message['user_country']) && $this->message['user_country'] != 'US') {
+      echo '- canProcess() - user_county: ' .  $this->message['user_country'] . ' does not support interest group assignment.', PHP_EOL;
+      return FALSE;
+    }
+
     return TRUE;
   }
 
@@ -91,12 +112,50 @@ class MBC_RegistrationEmail_CampaignSignup_Consumer extends MB_Toolbox_BaseConsu
    */
   protected function setter($message) {
 
+    // @todo: group by country rather than mailchimp_list_id
+
+    $this->waitingSubmissions[$this->message['mailchimp_list_id']][] = array(
+      'email' => array(
+        'email' => $this->message['email']
+      ),
+      'merge_vars' => array(
+        'groupings' => array(
+          0 => array(
+            'id' => $this->message['mailchimp_grouping_id'], // Campaigns2013 (10621), Campaigns2014 (10637) or Campaigns2015 (10641)
+            'groups' => array($this->message['mailchimp_group_name']),
+          )
+        ),
+      ),
+    );
   }
 
   /**
    * process(): Send composed settings to Mandrill to trigger transactional email message being sent.
    */
   protected function process() {
+
+    $results .= $this->submitToMailChimp($mAPIKey, $mlid, $composedSignupList, $mbDeliveryTags);
+
+    foreach ($this->waitingSubmissions as $mlid => $signups) {
+      // Batches of users by MailChimp List ID ($mlid)
+      // Assign MailChimp API Key based on user application_id signup source. Assume each
+      // $mlid batch will have the same application_id value. UK users are submitted to
+      // seperate MailChimp account.
+      if ($signups[0]['application_id'] == 'UK') {
+        $mAPIKey = $this->settings['mailchimp_uk_apikey'];
+      }
+      else {
+        $mAPIKey = $this->settings['mailchimp_apikey'];
+      }
+      list($composedSignupList, $mbDeliveryTags) = $this->composeSignupSubmission($signups);
+      if (count($composedSignupList) < 1) {
+        $results .= 'No new campaign signups accounts to submit to MailChimp list' . $mlid . '.' . PHP_EOL;
+        continue;
+      }
+
+      $results .= $this->submitToMailChimp($mAPIKey, $mlid, $composedSignupList, $mbDeliveryTags);
+
+    }
 
   }
 
@@ -132,6 +191,99 @@ class MBC_RegistrationEmail_CampaignSignup_Consumer extends MB_Toolbox_BaseConsu
     }
 
     return array($composedSubscriberList, $mbDeliveryTags);
+  }
+
+  /**
+   * processSubmissions(): Conditions to decide if current batch of users is ready for submission to MailChimp
+   *
+   * @return boolean
+   */
+  private function canProcessSubmissions() {
+
+    // @todo: Throttle the number of consumers running. Based on the number of messages
+    // waiting to be processed start / stop consumers. Make "reactive"!
+    $queueMessages = parent::queueStatus('userRegistrationQueue');
+    echo '- queueMessages ready: ' . $queueMessages['ready'], PHP_EOL;
+    echo '- queueMessages unacked: ' . $queueMessages['unacked'], PHP_EOL;
+
+    $waitingSubmissionsCount = $this->waitingSubmissionsCount($this->waitingSubmissions);
+    echo '- waitingSubmissionsCount: ' . $waitingSubmissionsCount, PHP_EOL;
+    if ($waitingSubmissionsCount >= self::BATCH_SIZE) {
+      return TRUE;
+    }
+
+    // Are there message still to be processed
+    if ($waitingSubmissionsCount != 0 && $waitingSubmissionsCount <= self::BATCH_SIZE) {
+      $waitingSubmissions = TRUE;
+    }
+    else {
+      $waitingSubmissions = FALSE;
+    }
+    // Idle time, process $waitingSubmissions if 5 minutes since last activity
+    if ($queueMessages['ready'] == 0 && (($this->lastSubmissionStamp - self::IDLE_TIME) < time())) {
+      $tiredOfWaiting = TRUE;
+    }
+    else {
+      $tiredOfWaiting = FALSE;
+    }
+    if ($waitingSubmissions && $tiredOfWaiting) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   *
+   */
+  protected function processSubmissions() {
+
+    // Grouped by country and list_ids to define Mailchimp account and which list to subscribe to
+    foreach ($this->waitingSubmissions as $country => $lists) {
+      $country = strtolower($country);
+      if (!(isset($this->mbcURMailChimp[$country]))) {
+        $country = 'global';
+      }
+      foreach ($lists as $listID => $submissions) {
+
+        try {
+          echo '-> submitting country: ' . $country, PHP_EOL;
+          $composedBatch = $this->mbcURMailChimp[$country]->composeSubscriberSubmission($submissions);
+          $results = $this->mbcURMailChimp[$country]->submitBatchSubscribe($listID, $composedBatch);
+          if (isset($results['error_count']) && $results['error_count'] > 0) {
+            $processSubmissionErrors = new MBC_RegistrationEmail_SubmissionErrors($this->mbcURMailChimp[$country], $listID);
+            $processSubmissionErrors->processSubmissionErrors($results['errors'], $composedBatch);
+          }
+        }
+        catch(Exception $e) {
+          echo 'Error: Failed to submit batch to ' . $country . ' MailChimp account. Error: ' . $e->getMessage(), PHP_EOL;
+          $this->channel->basic_cancel($this->message['original']->delivery_info['consumer_tag']);
+        }
+      }
+
+    }
+
+  }
+
+  /**
+   * waitingSubmissionsCount() - Calculate the total number of submissions ready to be batch submitted.
+   *
+   * @param array $waitingSubmissions
+   *   User submissions grouped by country and list_id
+   *
+   * @return integer $count
+   *   The total number of user records combined from all of the countries and their list_ids.
+   */
+  protected function waitingSubmissionsCount($waitingSubmissions = NULL) {
+
+    $count = 0;
+    foreach ($waitingSubmissions as $country => $list_id) {
+      foreach ($list_id as $id => $signups) {
+        $count += count($signups);
+      }
+    }
+
+    return $count;
   }
 
 }

--- a/src/MBC_RegistrationEmail_CampaignSignup_Consumer.php
+++ b/src/MBC_RegistrationEmail_CampaignSignup_Consumer.php
@@ -20,7 +20,7 @@ class MBC_RegistrationEmail_CampaignSignup_Consumer extends MB_Toolbox_BaseConsu
   /**
    * The number of queue entries to process in each session
    */
-  const BATCH_SIZE = 2;
+  const BATCH_SIZE = 50;
 
   /*
    * The amount of seconds to wait in an idle state before processing existing submissions even

--- a/src/MBC_RegistrationEmail_UserRegistration_Consumer.php
+++ b/src/MBC_RegistrationEmail_UserRegistration_Consumer.php
@@ -322,6 +322,7 @@ class MBC_RegistrationEmail_UserRegistration_Consumer extends MB_Toolbox_BaseCon
           $composedBatch = $this->mbcURMailChimp[$country]->composeSubscriberSubmission($submissions);
           $results = $this->mbcURMailChimp[$country]->submitBatchSubscribe($listID, $composedBatch);
           if (isset($results['error_count']) && $results['error_count'] > 0) {
+            echo '- ERRORS enountered in MailChimp submission... processing.', PHP_EOL;
             $processSubmissionErrors = new MBC_RegistrationEmail_SubmissionErrors($this->mbcURMailChimp[$country], $listID);
             $processSubmissionErrors->processSubmissionErrors($results['errors'], $composedBatch);
           }


### PR DESCRIPTION
Fixes #61 

- Refactor to use "modernized" consumer structure.
- Hardcode submisions for only US but leave some structure to support more than one MailChimp account based on `UserRegistration` class.