### PR TITLE
Fix MX and BR user subscriptions.

### DIFF
--- a/src/MBC_RegistrationEmail_UserRegistration_Consumer.php
+++ b/src/MBC_RegistrationEmail_UserRegistration_Consumer.php
@@ -359,6 +359,13 @@ class MBC_RegistrationEmail_UserRegistration_Consumer extends MB_Toolbox_BaseCon
 
         try {
           echo '-> submitting country: ' . $country, PHP_EOL;
+          // Override MX and BR API key with US.
+          // We don't need to use different API keys anymore because
+          // we add BR and MX users to US "International" list.
+          // The plan is to make sure nothing else is using BR and MX
+          // API keys and remove this functionality for good.
+          // For now, hardcoded override is the safest way to do it.
+          $country = 'us';
           $composedBatch = $this->mbcURMailChimp[$country]->composeSubscriberSubmission($submissions);
           $results = $this->mbcURMailChimp[$country]->submitBatchSubscribe($listID, $composedBatch);
           $this->statHat->ezCount('mbc-registration-email: MBC_RegistrationEmail_UserRegistration_Consumer: processSubmissions', 1);


### PR DESCRIPTION
#### What's this PR do?
- Fixes Mexican and Brazilian users MailChimp subscriptions on user registration

#### Any background context you want to provide?
Earlier Dee [overrode](https://github.com/DoSomething/mbc-registration-email/blob/2e0130d04d42187953ec4b9373fabe395b6cc822/src/MBC_RegistrationEmail_UserRegistration_Consumer.php#L226
) BR and MX users MailChimp list with "8e7844f6dd" ([International](https://us4.admin.mailchimp.com/lists/members?id=88069#p:1-s:10-so:null) list of US account). However, the code still uses API keys for BR and MX sub accounts, which have no access to US lists

#### What are the relevant tickets?
Fixes https://trello.com/c/RciDv1pJ/188-quicksilver-fix-br-and-mx-mailchimp-subscriptions-on-registration.
