### PR TITLE
Exclude all fake import addresses

### DIFF
--- a/src/MBC_RegistrationEmail_CampaignSignup_Consumer.php
+++ b/src/MBC_RegistrationEmail_CampaignSignup_Consumer.php
@@ -133,6 +133,12 @@ class MBC_RegistrationEmail_CampaignSignup_Consumer extends MB_Toolbox_BaseConsu
    */
   protected function canProcess($message) {
 
+    // Exclude generated emails adresses.
+    if (preg_match('/@.*\.import$/', $message['email'])) {
+      echo '- canProcess(), import placeholder address: ' . $message['email'], PHP_EOL;
+      return false;
+    }
+
     if (!(isset($message['mailchimp_grouping_id']))) {
       echo '- canProcess() - mailchimp_grouping_id not set.', PHP_EOL;
       return FALSE;

--- a/src/MBC_RegistrationEmail_UserRegistration_Consumer.php
+++ b/src/MBC_RegistrationEmail_UserRegistration_Consumer.php
@@ -158,6 +158,12 @@ class MBC_RegistrationEmail_UserRegistration_Consumer extends MB_Toolbox_BaseCon
       $message['email'] = filter_var($message['email'], FILTER_VALIDATE_EMAIL);
     }
 
+    // Exclude generated emails adresses.
+    if (preg_match('/@.*\.import$/', $this->message['email'])) {
+      echo '- canProcess(), import placeholder address: ' . $this->message['email'], PHP_EOL;
+      return false;
+    }
+
     if (!(isset($message['activity']))) {
       echo '- canProcess(), activity not set.', PHP_EOL;
       return FALSE;


### PR DESCRIPTION
#### What's this PR do?
- Excludes all possible combinations of fake import email addresses from being processed

#### Any background context you want to provide?
Drupal requires an email on every account, but Northstar does not. In order to create Phoenix profile for SMS-only users, we generate fake email address `id@@dosomething.import`, see https://github.com/DoSomething/northstar/pull/507/files#diff-eb9950cc3e4522e41dd68c31824f0497R125. This PR is to handle this exception and exclude this addresses from normal transactional email processing.

#### What are the relevant tickets?
- Same issue in mbc-transaction-email https://github.com/DoSomething/mbc-transactional-email/pull/49
- Trello https://trello.com/c/QRfWx8sn/288-unplanned-filter-out-dosomething-import-emails-from-being-processed
